### PR TITLE
Exclude abi stress on x86

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -313,6 +313,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/varargs/varargsupport_r/*">
             <Issue>Varargs supported on this platform</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Stress/ABI/*">
+            <Issue>26101</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows arm32 specific excludes -->


### PR DESCRIPTION
Do not run abi-stress on x86 windows. Note that we do not have any exclusions on x86 unix as it is not a currently supported platform.